### PR TITLE
Fix WebIDL for constructor

### DIFF
--- a/actions/index.html
+++ b/actions/index.html
@@ -188,7 +188,7 @@
             <pre class="idl">
               [Exposed=Window]
               interface CaptureActionEvent : Event {
-                constructor(CaptureActionEventInit init);
+                constructor(optional CaptureActionEventInit init = {});
                 readonly attribute CaptureAction action;
               };
             </pre>


### PR DESCRIPTION
Dictionaries used as argument needs to be optional defaulting to {} when they're a final argument per WebIDL spec