### PR TITLE
A Status of This Document must include at least one custom paragraph.

### DIFF
--- a/actions/index.html
+++ b/actions/index.html
@@ -18,8 +18,7 @@
     </section>
     <section id="sotd">
       <p>
-        This document is not complete. It is subject to major changes and, while early
-        experimentations are encouraged, it is therefore not intended for implementation.
+        This document is not complete.
       </p>
     </section>
     <section id="conformance"></section>

--- a/actions/index.html
+++ b/actions/index.html
@@ -16,6 +16,12 @@
         It describes a mechanism for <a data-cite="SCREEN-CAPTURE#dfn-browser">tab capture</a> only.
       </p>
     </section>
+    <section id="sotd">
+      <p>
+        This document is not complete. It is subject to major changes and, while early
+        experimentations are encouraged, it is therefore not intended for implementation.
+      </p>
+    </section>
     <section id="conformance"></section>
     <section>
       <h2>Problem Description</h2>

--- a/identity/index.html
+++ b/identity/index.html
@@ -16,6 +16,11 @@
         describes a mechanism for <a data-cite="SCREEN-CAPTURE#dfn-browser">tab capture</a> only.
       </p>
     </section>
+    <section id="sotd">
+      <p>
+        This document is not complete.
+      </p>
+    </section>
     <section id="conformance"></section>
     <section>
       <h2>Problem Description</h2>


### PR DESCRIPTION
Fix for Respec error:
> A Status of This Document must include at least on custom paragraph.
> 
> How to fix: Add a \<p\> in the 'sotd' section that reflects the status of this specification.
