### PR TITLE
Use selfBrowserSurface in demo

### DIFF
--- a/identity/demos/self_capture_detection/index.html
+++ b/identity/demos/self_capture_detection/index.html
@@ -179,7 +179,7 @@
 
         let stream;
         try {
-          stream = await navigator.mediaDevices.getDisplayMedia();
+          stream = await navigator.mediaDevices.getDisplayMedia({selfBrowserSurface: "include"});
         } catch (error) {
           update();
           return;


### PR DESCRIPTION
Without `selfBrowserSurface: "include"`, the demo is not useful on browsers that default to `"exclude"`.